### PR TITLE
Fix build error on non-Windows platforms

### DIFF
--- a/Runtime/Scripts/Client/MergePlotProxy.cs
+++ b/Runtime/Scripts/Client/MergePlotProxy.cs
@@ -32,8 +32,10 @@ public class MergePlotProxy : MonoBehaviour
         hideWindowButton.onClick.AddListener(SendHideWindowCommand);
 
         NamedPipeClientIPC.OnDataReceived += OnMessageReceived;
-        if (!launchProcess || string.IsNullOrWhiteSpace(processToLaunch)) return;
-        StartProcess(processToLaunch);
+#if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
+        if (launchProcess && !string.IsNullOrWhiteSpace(processToLaunch))
+            StartProcess(processToLaunch);
+#endif
     }
 
     //---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- guard the call to `StartProcess` with platform defines so `MergePlotProxy` builds on non-Windows platforms

## Testing
- `npm test` *(fails: Missing script)*