### PR TITLE
Add connection callbacks

### DIFF
--- a/Runtime/Scripts/Client/ClientServerIpcBridge.cs
+++ b/Runtime/Scripts/Client/ClientServerIpcBridge.cs
@@ -24,6 +24,7 @@ public class ClientServerIpcBridge : MonoBehaviour
     void Start()
     {
         NamedPipeClientIPC.OnDataReceived += OnMessageReceived;
+        NamedPipeClientIPC.OnConnected    += OnPipeConnected;
 
 #if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
         if (launchProcess && !string.IsNullOrWhiteSpace(processToLaunch))
@@ -35,6 +36,7 @@ public class ClientServerIpcBridge : MonoBehaviour
     void OnDestroy()
     {
         NamedPipeClientIPC.OnDataReceived -= OnMessageReceived;
+        NamedPipeClientIPC.OnConnected    -= OnPipeConnected;
 
 #if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
         processController.Stop();
@@ -121,5 +123,11 @@ public class ClientServerIpcBridge : MonoBehaviour
 #else
         Debug.LogWarning("Process control is only supported on Windows.");
 #endif
+    }
+
+    //--------------------------------------------------------------------------
+    void OnPipeConnected()
+    {
+        Debug.Log("[Client] Pipe connected.");
     }
 }

--- a/Runtime/Scripts/Server/HumanaMachinaIpcBridge.cs
+++ b/Runtime/Scripts/Server/HumanaMachinaIpcBridge.cs
@@ -19,6 +19,7 @@ public class HumanaMachinaIpcBridge : MonoBehaviour
         _windowCtrl = new WindowController();
         hideWindowButton.onClick.AddListener(OnHideWindowClicked);
         NamedPipeServerIPC.OnDataReceived += OnMessageReceived;
+        NamedPipeServerIPC.OnConnected    += OnPipeConnected;
     }
 
     //---------------------------------------------------------------------------
@@ -26,6 +27,7 @@ public class HumanaMachinaIpcBridge : MonoBehaviour
     {
         hideWindowButton.onClick.RemoveListener(OnHideWindowClicked);
         NamedPipeServerIPC.OnDataReceived -= OnMessageReceived;
+        NamedPipeServerIPC.OnConnected    -= OnPipeConnected;
     }
 
     //---------------------------------------------------------------------------
@@ -98,5 +100,11 @@ public class HumanaMachinaIpcBridge : MonoBehaviour
 
         if (logReceivedData)
             Debug.Log(JsonUtility.ToJson(msg));
+    }
+
+    //--------------------------------------------------------------------------
+    void OnPipeConnected()
+    {
+        Debug.Log("[Server] Pipe connected.");
     }
 }


### PR DESCRIPTION
## Summary
- add `OnConnected` callback to the named pipe base
- notify connection events in the pipe bridge classes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684761dc54188321909133a1488dba31